### PR TITLE
added option to not show the alert dialog that the icon changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ To integrate your plugin into the iOS part of your app, follow these steps
     2. Add `CFBundleAlternateIcons` as a dictionary, it is used for alternative icons
     3. Set 3 dictionaries under `CFBundleAlternateIcons`, they are correspond to `teamfortress`, `photos`, and `chills`
     4. For each dictionary, two properties — `UIPrerenderedIcon` and `CFBundleIconFiles` need to be configured
+	5. If the sub-property `UINewsstandIcon` is showing under `Icon files (iOS 5)` and you don't play on using it (it is intended for use with Newstand features), erase it or the app will get rejected upon submission on the App Store
 
 
 Note that if you need it work for iPads, You need to add these icon declarations in `CFBundleIcons~ipad` as well. [See here](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-SW14) for more details.

--- a/ios/Classes/FLTDynamicIconPlugin.m
+++ b/ios/Classes/FLTDynamicIconPlugin.m
@@ -29,15 +29,42 @@
                     if (iconName == [NSNull null]) {
                         iconName = nil;
                     }
-                    [UIApplication.sharedApplication setAlternateIconName:iconName completionHandler:^(NSError * _Nullable error) {
-                        if(error) {
-                            result([FlutterError errorWithCode:@"Failed to set icon"
-                                                    message:[error description]
-                                                    details:nil]);
-                        } else {
-                            result(nil);
+                    
+                    NSString *stringAlert = call.arguments[@"showAlert"];
+
+                    if([stringAlert isEqualToString:@"false"]){
+                        NSMutableString *selectorString = [[NSMutableString alloc] initWithCapacity:40];
+                        [selectorString appendString:@"_setAlternate"];
+                        [selectorString appendString:@"IconName:"];
+                        [selectorString appendString:@"completionHandler:"];
+
+                        SEL selector = NSSelectorFromString(selectorString);
+                        IMP imp = [[UIApplication sharedApplication] methodForSelector:selector];
+                        void (*func)(id, SEL, id, id) = (void *)imp;
+                        if (func)
+                        {
+                            func([UIApplication sharedApplication], selector, iconName, ^(NSError * _Nullable error) {
+                                if(error) {
+                                    result([FlutterError errorWithCode:@"Failed to set icon"
+                                                            message:[error description]
+                                                            details:nil]);
+                                } else {
+                                    result(nil);
+                                }
+                            });
                         }
-                    }];
+                        
+                    }else{
+                        [UIApplication.sharedApplication setAlternateIconName:iconName completionHandler:^(NSError * _Nullable error) {
+                            if(error) {
+                                result([FlutterError errorWithCode:@"Failed to set icon"
+                                                        message:[error description]
+                                                        details:nil]);
+                            } else {
+                                result(nil);
+                            }
+                        }];
+                    }
                 }
                 @catch (NSException *exception) {
                     NSLog(@"%@", exception.reason);

--- a/lib/flutter_dynamic_icon.dart
+++ b/lib/flutter_dynamic_icon.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-
 import 'package:flutter/services.dart';
 
 class FlutterDynamicIcon {
@@ -27,10 +26,14 @@ class FlutterDynamicIcon {
   ///
   /// Throws a [PlatformException] with description if
   /// it can't find [iconName] or there's any other error
-  static Future setAlternateIconName(String? iconName) async {
+  static Future setAlternateIconName(String? iconName,
+      {bool showAlert = true}) async {
     await _channel.invokeMethod(
       'mSetAlternateIconName',
-      <String, dynamic>{'iconName': iconName},
+      <String, dynamic>{
+        'iconName': iconName,
+        'showAlert': showAlert ? 'true' : 'false',
+      },
     );
   }
 


### PR DESCRIPTION
This is the only way I found to not show the alert in Objective C. I added the option from flutter so the developer can choose wether or not s/he wants to show it.

I couldn't find a way to send a bool through the invoke method, that is why i did it as a string. Maybe you know a better way.

For all I've seen this won't get your app rejected by the app store review. But I left the option in case someone faces the issue and can easily change it back to the basic configuration.