### PR TITLE
Bugfix/delete deprecation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,13 +2,15 @@ group 'io.github.tastelessjolt.flutterdynamicicon'
 version '1.0-SNAPSHOT'
 
 buildscript {
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:8.1.4'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -20,14 +22,25 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 
 android {
     namespace "io.github.tastelessjolt.flutterdynamicicon"
 
-    compileSdkVersion 31
+    compileSdkVersion 34
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
 
     defaultConfig {
-        minSdkVersion 16
+        namespace "io.github.tastelessjolt.flutterdynamicicon"
+        minSdkVersion 23
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="io.github.tastelessjolt.flutterdynamicicon">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/tastelessjolt/flutter_dynamic_icon
 issue_tracker: https://github.com/tastelessjolt/flutter_dynamic_icon/issues
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: '>=2.0.0'
+  sdk: ">=3.1.3 <4.0.0"
+  flutter: ">=3.16.4"
 
 dependencies:
   flutter:


### PR DESCRIPTION
After Flutter 3.29, registerWith method is deleted.

detail → https://medium.com/@bmerdogan/flutter-3-29-deprecates-pluginregistry-registrar-migration-guide-0f206232b768